### PR TITLE
Handle case of null expressions in all publications

### DIFF
--- a/susdingest/jsonloader.py
+++ b/susdingest/jsonloader.py
@@ -65,8 +65,12 @@ class JSONLoader:
              'journal_publishername', 'journal_title', 'journal_scopus_source_id']
         ].assign(journal_issn_isbn=self.data['journal_issn_isbn']
                  .apply(lambda x: '|'.join(str(i) for i in x) if x == x else x))
-        publications['tested_expressions'] = self.data['expressions'] \
-                                                 .apply(lambda x: json.dumps(x) if x == x else x)
+        if 'expressions' not in self.data:
+            publications['tested_expressions'] = pd.NA
+        else:
+            publications['tested_expressions'] = self.data[
+                'expressions'
+            ].apply(lambda x: json.dumps(x) if x == x else x)
         citescore = self.normalize_col('journal_citescore', explode=False) \
                         .rename(columns=lambda x: f'journal_{x}')
         return publications.join(citescore).convert_dtypes()


### PR DESCRIPTION
At some point we will likely need a more generic way to do this for any column that can be nulled as identified in json schema, but for now this should enable handling of all real-world datasets.